### PR TITLE
fix: Don't support editions

### DIFF
--- a/cmd/protoc-gen-jsonschema/main.go
+++ b/cmd/protoc-gen-jsonschema/main.go
@@ -12,6 +12,6 @@ import (
 )
 
 func main() {
-	supportedFeatures := uint64(pluginpb.CodeGeneratorResponse_FEATURE_PROTO3_OPTIONAL | pluginpb.CodeGeneratorResponse_FEATURE_SUPPORTS_EDITIONS)
+	supportedFeatures := uint64(pluginpb.CodeGeneratorResponse_FEATURE_PROTO3_OPTIONAL)
 	pgs.Init(pgs.SupportedFeatures(&supportedFeatures), pgs.DebugEnv(common.DebugEnv)).RegisterModule(module.New()).Render()
 }


### PR DESCRIPTION
To support editions we need to declare the minimum edition we support, otherwise we get

```
supported_features: FEATURE_SUPPORTS_EDITIONS specified but no minimum_edition set
```

Unfortunately protoc-gen-star does not yet support setting the minimum edition: https://github.com/lyft/protoc-gen-star/pull/132

For now, we can drop `FEATURE_SUPPORTS_EDITIONS`.